### PR TITLE
Allow disabling row counts in REST resources.

### DIFF
--- a/flask_peewee/rest/__init__.py
+++ b/flask_peewee/rest/__init__.py
@@ -92,6 +92,8 @@ class RestResource(object):
     # http methods supported for `edit` operations.
     edit_methods = ('PATCH', 'PUT', 'POST')
 
+    enable_row_count = True
+
     prefetch = []
 
     @classmethod
@@ -663,7 +665,7 @@ class RestResource(object):
 
         return {
             'model': self.get_api_name(),
-            'count': paginated_query.query.count(),
+            'count': paginated_query.query.count() if self.enable_row_count else None,
             'page': current_page,
             'previous': previous_page,
             'next': next_page,

--- a/flask_peewee/rest/__init__.py
+++ b/flask_peewee/rest/__init__.py
@@ -476,6 +476,9 @@ class RestResource(object):
     def response_bad_request(self):
         return Response('Bad request', 400)
 
+    def response_not_found(self):
+        return Response('Not found', 404)
+
     def response_api_exception(self, data, status=400):
         return Response(json.dumps(data), status, mimetype='application/json')
 
@@ -596,6 +599,9 @@ class RestResource(object):
         return self.get_registry()
 
     def api_count(self):
+        if not self.enable_row_count:
+            return self.response_not_found()
+
         if not self.check_http_method():
             return self.response_forbidden()
 

--- a/flask_peewee/tests/test_app.py
+++ b/flask_peewee/tests/test_app.py
@@ -157,6 +157,7 @@ class EResource(DeletableResource):
 
 class FResource(DeletableResource):
     include_resources = {'e': EResource}
+    enable_row_count = False
 
 
 class JResource(DeletableResource):

--- a/flask_peewee/tests/test_rest.py
+++ b/flask_peewee/tests/test_rest.py
@@ -181,6 +181,16 @@ class RestApiResourceTestCase(RestApiTestCase):
         resp = self.app.get('/api/amodel/_count')
         self.assertEqual(resp.get_json()['count'], 2)
 
+        resp = self.app.get('/api/amodel')
+        self.assertEqual(resp.get_json()['meta']['count'], 2)
+
+        # fmodel
+        resp = self.app.get('/api/fmodel/_count')
+        self.assertEqual(resp.status_code, 404)
+
+        resp = self.app.get('/api/fmodel')
+        self.assertEqual(resp.get_json()['meta']['count'], None)
+
     def test_resources_exportable(self):
         self.create_test_models()
 


### PR DESCRIPTION
Count queries in postgres can be very slow, allow disabling them for large tables.