### PR TITLE
sidestep issues with freezegun

### DIFF
--- a/flask_peewee/rest/serializer.py
+++ b/flask_peewee/rest/serializer.py
@@ -33,9 +33,9 @@ class Serializer(object):
 
     def format_datetime(self, value):
         if self.datetime_formatter == 'timestamp_ms':
-            return int(datetime.datetime.timestamp(value) * 1000)
+            return int(value.timestamp() * 1000)
         if self.datetime_formatter == 'timestamp':
-            return int(datetime.datetime.timestamp(value))
+            return int(value.timestamp())
         return value.strftime(self.datetime_format)
 
     def clean_data(self, data):

--- a/flask_peewee/tests/requirements.txt
+++ b/flask_peewee/tests/requirements.txt
@@ -1,11 +1,12 @@
 blinker==1.4
 Flask==1.1.1
 Flask-Login==0.4.1
+itsdangerous==1.1.0
 Jinja2==2.10.3
+markupsafe==2.0.1
 peewee==3.13.1
 psycopg2-binary==2.8.6
 pytest==6.2.4
 wtf-peewee==3.0.0
 WTForms==2.2.1
 flake8
-markupsafe==2.0.1

--- a/flask_peewee/tests/requirements.txt
+++ b/flask_peewee/tests/requirements.txt
@@ -8,3 +8,4 @@ pytest==6.2.4
 wtf-peewee==3.0.0
 WTForms==2.2.1
 flake8
+markupsafe==2.0.1


### PR DESCRIPTION
## Context

See https://github.com/spulec/freezegun/issues/400 and https://propel-team.slack.com/archives/C01KYCVGUKX/p1647465767116459

The use of the undocumented `datetime.datetime.timestamp` is leading to issues. The idea is to replace the old pattern with the new on where you just use the `timestamp` method. 