### PR TITLE
Fix CI tests and compatibility with newer peewee.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     services:
       postgres:
         image: postgres

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
     services:
       postgres:
         image: postgres

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,18 +1,15 @@
-@Library('jenkins-shared-library@master') _
-
-def mainBranch = 'master'
+@Library('jenkins-shared-library@main') _
 
 standardBuild(
   version: 2,
   skipBranchBuilds: true,
-  mainBranch: mainBranch,
   jobDescription: 'Uploads flask-peewee module to private devpi repository',
   properties: [buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10'))],
 ) { TAG, BRANCH_NAME, GIT_SHA ->
 
   // Upload flask-peewee to private devpi repository
   stage("Upload flask-peewee") {
-    if (BRANCH_NAME == mainBranch) {
+    if (BRANCH_NAME == config.mainBranch) {
       utils.uploadPyModule(path: ".")
     }
   }

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ flask-peewee
 .. image:: https://img.shields.io/badge/License-MIT%20License-blue.svg
   :target: https://raw.githubusercontent.com/rammie/flask-peewee/master/LICENSE
 
-.. image:: https://api.travis-ci.org/rammie/flask-peewee.png?branch=master
-  :target: https://travis-ci.org/rammie/flask-peewee
+.. image:: https://github.com/propelinc/flask-peewee/actions/workflows/tests.yaml/badge.svg?branch=main
+  :target: https://github.com/propelinc/flask-peewee/actions/workflows/tests.yaml?branch=main
 
 This fork is different in the following ways:
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ flask-peewee
 ============
 
 .. image:: https://img.shields.io/badge/License-MIT%20License-blue.svg
-  :target: https://raw.githubusercontent.com/rammie/flask-peewee/master/LICENSE
+  :target: https://raw.githubusercontent.com/propelinc/flask-peewee/main/LICENSE
 
 .. image:: https://github.com/propelinc/flask-peewee/actions/workflows/tests.yaml/badge.svg?branch=main
   :target: https://github.com/propelinc/flask-peewee/actions/workflows/tests.yaml?branch=main

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -69,7 +69,7 @@ To get started with the admin, there are just a couple steps:
 Customizing how models are displayed
 ------------------------------------
 
-We'll use the "Message" model taken from the `example app <https://github.com/coleifer/flask-peewee/tree/master/example>`_,
+We'll use the "Message" model taken from the `example app <https://github.com/propelinc/flask-peewee/tree/main/example>`_,
 which looks like this:
 
 .. code-block:: python
@@ -224,7 +224,7 @@ Some example use-cases for AdminPanels might be:
   for example a mailing-list app.
 * Control global site settings, turn on and off features, etc.
 
-Referring to the `example app <https://github.com/coleifer/flask-peewee/tree/master/example>`_,
+Referring to the `example app <https://github.com/propelinc/flask-peewee/tree/main/example>`_,
 we'll look at a simple panel that allows administrators to leave "notes" in the admin area:
 
 .. image:: fp-note-panel.jpg

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -12,7 +12,7 @@ further ado, let's get started.
     should help you get started.
 
 .. note::
-    For a complete example project, check the `example app <https://github.com/coleifer/flask-peewee/tree/master/example>`_
+    For a complete example project, check the `example app <https://github.com/propelinc/flask-peewee/tree/main/example>`_
     that ships with flask-peewee.
 
 

--- a/docs/rest-api.rst
+++ b/docs/rest-api.rst
@@ -337,7 +337,7 @@ It is fine to modify our own message, though (message with id=1):
     
     # prints 200
 
-Under-the-hood, the `implementation <https://github.com/coleifer/flask-peewee/blob/master/flask_peewee/rest.py#L284>`_ of the :py:class:`RestrictOwnerResource` is pretty simple.
+Under-the-hood, the `implementation <https://github.com/propelinc/flask-peewee/blob/main/flask_peewee/rest.py#L284>`_ of the :py:class:`RestrictOwnerResource` is pretty simple.
 
 * PUT / DELETE -- verify the authenticated user is the owner of the object
 * POST -- assign the authenticated user as the owner of the new object

--- a/flask_peewee/tests/requirements.txt
+++ b/flask_peewee/tests/requirements.txt
@@ -5,8 +5,9 @@ itsdangerous==1.1.0
 Jinja2==2.10.3
 markupsafe==2.0.1
 peewee==3.13.1
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.5
 pytest==6.2.4
+pytz==2023.3
 wtf-peewee==3.0.0
 WTForms==2.2.1
 flake8

--- a/flask_peewee/tests/requirements.txt
+++ b/flask_peewee/tests/requirements.txt
@@ -8,6 +8,7 @@ peewee==3.13.1
 psycopg2-binary==2.9.5
 pytest==6.2.4
 pytz==2023.3
+werkzeug==0.16.0
 wtf-peewee==3.0.0
 WTForms==2.2.1
 flake8

--- a/flask_peewee/tests/test_app.py
+++ b/flask_peewee/tests/test_app.py
@@ -18,6 +18,7 @@ from flask_peewee.rest import Authentication
 from flask_peewee.rest import RestAPI
 from flask_peewee.rest import RestResource
 from flask_peewee.rest import RestrictOwnerResource
+from flask_peewee.rest.stats import StatsMixin
 
 
 class FlaskApp(Flask):
@@ -160,7 +161,7 @@ class FResource(DeletableResource):
     enable_row_count = False
 
 
-class JResource(DeletableResource):
+class JResource(StatsMixin, DeletableResource):
     editable_json_fields = ('j_field', )
 
 class V2Resource(DeletableResource):

--- a/flask_peewee/tests/test_rest.py
+++ b/flask_peewee/tests/test_rest.py
@@ -555,6 +555,29 @@ class RestApiResourceTestCase(RestApiTestCase):
         f_obj = FModel.get(id=self.f1.id)
         self.assertEqual(f_obj.e, None)
 
+    def test_stats(self):
+        # test that stats mixin supports getting count
+        resp = self.app.get('/api/jmodel/stats/')
+        self.assertEqual(
+            resp.get_json(),
+            {'meta': {'aliases': ['count_id']}, 'objects': [{'count_id': 0}]})
+
+        self.create_test_models()
+        resp = self.app.get('/api/jmodel/stats/')
+        self.assertEqual(
+            resp.get_json(),
+            {'meta': {'aliases': ['count_id']}, 'objects': [{'count_id': 1}]})
+
+    def test_json_stats(self):
+        # test that stats mixin supports getting count and keys on JSON fields
+        resp = self.app.get('/api/jmodel/keys/j_field')
+        self.assertEqual(resp.get_json(), {'keys': []})
+
+        self.create_test_models()
+        resp = self.app.get('/api/jmodel/keys/j_field')
+        keys = resp.get_json()["keys"]
+        self.assertEqual(set(keys), {'n', 'foo', 'bar'})
+
     def test_json_filtering(self):
         # test that filtering on JSON fields works
         resp = self.app.get('/api/jmodel?j_field.bar=car')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 requirements = ['Flask', 'werkzeug', 'jinja2', 'peewee>=3.0.0', 'wtforms', 'wtf-peewee']
 setup(
     name='flask-peewee',
-    version='3.0.4-propel',
+    version='3.0.5-propel',
     url='http://github.com/coleifer/flask-peewee/',
     license='MIT',
     author='Charles Leifer',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements = ['Flask', 'werkzeug', 'jinja2', 'peewee>=3.0.0', 'wtforms', 'wtf-
 setup(
     name='flask-peewee',
     version='3.0.5-propel',
-    url='http://github.com/coleifer/flask-peewee/',
+    url='http://github.com/propelinc/flask-peewee/',
     license='MIT',
     author='Charles Leifer',
     author_email='coleifer@gmail.com',


### PR DESCRIPTION
* Update imports to worker with newer versions of peewee.
* Pin packages in requirements.txt to make tests pass in CI.
* Update README to point to github actions badge.
* Remove unused `filter_query` function.