### PR TITLE
Specify propel package in a more conformant way

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 requirements = ['Flask', 'werkzeug', 'jinja2', 'peewee>=3.0.0', 'wtforms', 'wtf-peewee']
 setup(
     name='flask-peewee',
-    version='3.0.5-propel',
+    version='3.0.5',
     url='http://github.com/propelinc/flask-peewee/',
     license='MIT',
     author='Charles Leifer',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 requirements = ['Flask', 'werkzeug', 'jinja2', 'peewee>=3.0.0', 'wtforms', 'wtf-peewee']
 setup(
     name='flask-peewee',
-    version='3.0.5',
+    version='3.0.5+propel',
     url='http://github.com/propelinc/flask-peewee/',
     license='MIT',
     author='Charles Leifer',


### PR DESCRIPTION
Local versions should use a `+` as a specifier. This is required for using this package with the [uv installer](https://github.com/astral-sh/uv) rather than pip. Without this, we get `InvalidVersion` errors from setuptools.

- [pip documentation](https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-identifiers)
- [Relevant Github comment](https://github.com/pypa/setuptools/issues/3772#issuecomment-1384342813)