### PR TITLE
Python 3.13 compatibility

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     services:
       postgres:
         image: postgres
@@ -21,8 +21,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: pip deps

--- a/flask_peewee/tests/requirements.txt
+++ b/flask_peewee/tests/requirements.txt
@@ -12,4 +12,4 @@ werkzeug==0.16.0
 wtf-peewee==3.0.0
 WTForms==2.2.1
 flake8
-legacy-cgi; python_version > '3.13'
+legacy-cgi; python_version >= '3.13'

--- a/flask_peewee/tests/requirements.txt
+++ b/flask_peewee/tests/requirements.txt
@@ -5,7 +5,7 @@ itsdangerous==1.1.0
 Jinja2==2.10.3
 markupsafe==2.0.1
 peewee==3.13.1
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.10
 pytest==6.2.4
 pytz==2023.3
 werkzeug==0.16.0

--- a/flask_peewee/tests/requirements.txt
+++ b/flask_peewee/tests/requirements.txt
@@ -12,3 +12,4 @@ werkzeug==0.16.0
 wtf-peewee==3.0.0
 WTForms==2.2.1
 flake8
+legacy-cgi; python_version > '3.13'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup, find_packages
 
-requirements = ['Flask', 'werkzeug', 'jinja2', 'peewee>=3.0.0', 'wtforms', 'wtf-peewee']
+requirements = ['Flask', 'werkzeug', 'jinja2', 'peewee>=3.0.0', 'wtforms', 'wtf-peewee', "legacy-cgi; python_version >= '3.13'"]
+
+
 setup(
     name='flask-peewee',
     version='3.0.5+propel',


### PR DESCRIPTION
Looks like Ram introduced a usage for escaping html via `cgi` module into our `flask-peewee` fork. This isn't in the upstream repo. The `cgi` module was removed from python in version 3.13, with the ask that folks use a third-party lib for this functionality moving forward.

To get Python 3.13 to work with our fork of `flask-peewee`, we can use a `legacy-cgi` repo that is meant to be a drop-in replacement. I added it both to the requirements for installing the package, as well as the test requirements.